### PR TITLE
feat: show category preset if "카테고리" in deny reason

### DIFF
--- a/pages/pendingBots/[id]/[date].tsx
+++ b/pages/pendingBots/[id]/[date].tsx
@@ -61,7 +61,11 @@ const PendingBot: NextPage<PendingBotProps> = ({ data }) => {
 											{BotSubmissionDenyReasonPresetsName[data.reason] || data.reason}
 										</strong>
 									</p>
-									<div className='pt-2'>{DenyPresetsArticle[data.reason]}</div>
+									<div className='pt-2'>
+										{data.reason.includes('카테고리')
+											? DenyPresetsArticle.INVALID_CATEGORY
+											: DenyPresetsArticle[data.reason]}
+									</div>
 								</>
 							)}
 							<div className='pt-2'>


### PR DESCRIPTION
- 거부 사유에 "카테고리" 문자열이 포함된 경우 카테고리 미일치 프리셋을 함께 표시합니다.