### PR TITLE
feat: 카테고리 태그 더보기/접기 기능

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -131,6 +131,7 @@ const Hero: React.FC<HeroProps> = ({ type = 'all', header, description }) => {
 									))}
 								<Tag
 									key='tag'
+									className='cursor-pointer'
 									text={
 										<>
 											<i className='fas fa-tag' />{' '}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,6 @@
-import dynamic from 'next/dynamic'
 import { NextSeo } from 'next-seo'
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
 
 import {
 	botCategories,
@@ -13,6 +14,7 @@ const Tag = dynamic(() => import('@components/Tag'))
 const Search = dynamic(() => import('@components/Search'))
 
 const Hero: React.FC<HeroProps> = ({ type = 'all', header, description }) => {
+	const [showAllCategories, setShowAllCategories] = useState(false)
 	const link = `/${type}/categories`
 	return (
 		<>
@@ -109,32 +111,35 @@ const Hero: React.FC<HeroProps> = ({ type = 'all', header, description }) => {
 									bigger
 									href={type === 'bots' ? '/bots/list/votes' : '/servers/list/votes'}
 								/>
-								{(type === 'bots' ? botCategories : serverCategories).slice(0, 4).map((t) => (
-									<Tag
-										key={t}
-										text={
-											<>
-												<i
-													className={(type === 'bots' ? botCategoryIcon : serverCategoryIcon)[t]}
-												/>{' '}
-												{t}
-											</>
-										}
-										dark
-										bigger
-										href={`${link}/${t}`}
-									/>
-								))}
+								{(type === 'bots' ? botCategories : serverCategories)
+									.slice(0, showAllCategories ? undefined : 4)
+									.map((t) => (
+										<Tag
+											key={t}
+											text={
+												<>
+													<i
+														className={(type === 'bots' ? botCategoryIcon : serverCategoryIcon)[t]}
+													/>{' '}
+													{t}
+												</>
+											}
+											dark
+											bigger
+											href={`${link}/${t}`}
+										/>
+									))}
 								<Tag
 									key='tag'
 									text={
 										<>
-											<i className='fas fa-tag' /> 카테고리 더보기
+											<i className='fas fa-tag' />{' '}
+											{showAllCategories ? '간략히 보기' : '카테고리 더보기'}
 										</>
 									}
 									dark
 									bigger
-									href={link}
+									onClick={() => setShowAllCategories(!showAllCategories)}
 								/>
 							</>
 						)}


### PR DESCRIPTION
- 본래의 /bots/categories 와 /servers/categories 로 라우팅 하는 것 대신 카테고리 태그에 대해 더보기-접기 가 가능하도록 하여 UI개선
<img width="564" alt="image" src="https://github.com/user-attachments/assets/551a50b8-465a-4db7-aba5-d90d0b40e2ce" />
<img width="560" alt="image" src="https://github.com/user-attachments/assets/8bcf188d-e494-4401-bfed-aabc4c631a9f" />


