### PR TITLE
chore: 리턴링크 띄어쓰기 수정

### DIFF
--- a/pages/bots/[id]/report.tsx
+++ b/pages/bots/[id]/report.tsx
@@ -1,7 +1,7 @@
-import { NextPage } from 'next'
-import Link from 'next/link'
-import dynamic from 'next/dynamic'
 import { Field, Form, Formik } from 'formik'
+import { NextPage } from 'next'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
 
 import { Bot, CsrfContext, ResponseProps, User } from '@types'
 import { get } from '@utils/Query'
@@ -9,15 +9,15 @@ import { makeBotURL, parseCookie } from '@utils/Tools'
 
 import { ParsedUrlQuery } from 'querystring'
 
-import NotFound from 'pages/404'
-import { getToken } from '@utils/Csrf'
 import { DMCA, TextField } from '@components/ReportTemplate'
-import { useState } from 'react'
+import { reportCats } from '@utils/Constants'
+import { getToken } from '@utils/Csrf'
 import Fetch from '@utils/Fetch'
 import { ReportSchema } from '@utils/Yup'
 import { getJosaPicker } from 'josa'
-import { reportCats } from '@utils/Constants'
 import { NextSeo } from 'next-seo'
+import NotFound from 'pages/404'
+import { useState } from 'react'
 
 const Container = dynamic(() => import('@components/Container'))
 const Message = dynamic(() => import('@components/Message'))
@@ -37,7 +37,7 @@ const ReportBot: NextPage<ReportBotProps> = ({ data, user, csrfToken }) => {
 			<NextSeo title={`${data.name} 신고하기`} />
 			<Link href={makeBotURL(data)} className='text-blue-500 hover:opacity-80'>
 				<i className='fas fa-arrow-left mb-3 mt-3' /> <strong>{data.name}</strong>
-				{getJosaPicker('로')(data.name)}돌아가기
+				{getJosaPicker('로')(data.name)} 돌아가기
 			</Link>
 			{reportRes?.code === 200 ? (
 				<Message type='success'>

--- a/pages/bots/[id]/vote.tsx
+++ b/pages/bots/[id]/vote.tsx
@@ -1,24 +1,24 @@
 import { NextPage } from 'next'
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { Bot, CsrfContext, ResponseProps, Theme, User } from '@types'
 import { get } from '@utils/Query'
-import { makeBotURL, parseCookie, checkBotFlag } from '@utils/Tools'
+import { checkBotFlag, makeBotURL, parseCookie } from '@utils/Tools'
 
 import { ParsedUrlQuery } from 'querystring'
 
-import NotFound from 'pages/404'
-import { getToken } from '@utils/Csrf'
 import Captcha from '@components/Captcha'
-import { useEffect, useRef, useState } from 'react'
-import Fetch from '@utils/Fetch'
-import Day from '@utils/Day'
-import { getJosaPicker } from 'josa'
-import { KoreanbotsEndPoints } from '@utils/Constants'
-import { NextSeo } from 'next-seo'
 import SetNotification, { getFCMToken } from '@components/FCM'
+import { KoreanbotsEndPoints } from '@utils/Constants'
+import { getToken } from '@utils/Csrf'
+import Day from '@utils/Day'
+import Fetch from '@utils/Fetch'
+import { getJosaPicker } from 'josa'
+import { NextSeo } from 'next-seo'
+import NotFound from 'pages/404'
+import { useEffect, useRef, useState } from 'react'
 
 const Container = dynamic(() => import('@components/Container'))
 const DiscordAvatar = dynamic(() => import('@components/DiscordAvatar'))
@@ -98,7 +98,7 @@ const VoteBot: NextPage<VoteBotProps> = ({ data, user, theme, csrfToken }) => {
 					<Advertisement />
 					<Link href={makeBotURL(data)} className='text-blue-500 hover:opacity-80'>
 						<i className='fas fa-arrow-left mb-3 mt-3' /> <strong>{data.name}</strong>
-						{getJosaPicker('로')(data.name)}돌아가기
+						{getJosaPicker('로')(data.name)} 돌아가기
 					</Link>
 					<Segment className='mb-16 py-8'>
 						<div className='text-center'>

--- a/pages/servers/[id]/report.tsx
+++ b/pages/servers/[id]/report.tsx
@@ -1,23 +1,23 @@
-import { NextPage } from 'next'
-import Link from 'next/link'
-import dynamic from 'next/dynamic'
 import { Field, Form, Formik } from 'formik'
+import { NextPage } from 'next'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
 
-import { Server, CsrfContext, ResponseProps, User } from '@types'
+import { CsrfContext, ResponseProps, Server, User } from '@types'
 import { get } from '@utils/Query'
 import { makeServerURL, parseCookie } from '@utils/Tools'
 
 import { ParsedUrlQuery } from 'querystring'
 
-import NotFound from 'pages/404'
-import { getToken } from '@utils/Csrf'
 import { DMCA, TextField } from '@components/ReportTemplate'
-import { useState } from 'react'
+import { serverReportCats } from '@utils/Constants'
+import { getToken } from '@utils/Csrf'
 import Fetch from '@utils/Fetch'
 import { ReportSchema } from '@utils/Yup'
 import { getJosaPicker } from 'josa'
-import { serverReportCats } from '@utils/Constants'
 import { NextSeo } from 'next-seo'
+import NotFound from 'pages/404'
+import { useState } from 'react'
 
 const Container = dynamic(() => import('@components/Container'))
 const Message = dynamic(() => import('@components/Message'))
@@ -37,7 +37,7 @@ const ReportServer: NextPage<ReportServerProps> = ({ data, user, csrfToken }) =>
 			<NextSeo title={`${data.name} 신고하기`} />
 			<Link href={makeServerURL(data)} className='text-blue-500 hover:opacity-80'>
 				<i className='fas fa-arrow-left mb-3 mt-3' /> <strong>{data.name}</strong>
-				{getJosaPicker('로')(data.name)}돌아가기
+				{getJosaPicker('로')(data.name)} 돌아가기
 			</Link>
 			{reportRes?.code === 200 ? (
 				<Message type='success'>

--- a/pages/servers/[id]/vote.tsx
+++ b/pages/servers/[id]/vote.tsx
@@ -1,24 +1,24 @@
 import { NextPage } from 'next'
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { CsrfContext, ResponseProps, Server, Theme, User } from '@types'
 import { get } from '@utils/Query'
-import { parseCookie, checkServerFlag, makeServerURL } from '@utils/Tools'
+import { checkServerFlag, makeServerURL, parseCookie } from '@utils/Tools'
 
 import { ParsedUrlQuery } from 'querystring'
 
-import NotFound from 'pages/404'
-import { getToken } from '@utils/Csrf'
 import Captcha from '@components/Captcha'
-import { useEffect, useRef, useState } from 'react'
-import Fetch from '@utils/Fetch'
-import Day from '@utils/Day'
-import { getJosaPicker } from 'josa'
-import { KoreanbotsEndPoints } from '@utils/Constants'
-import { NextSeo } from 'next-seo'
 import SetNotification, { getFCMToken } from '@components/FCM'
+import { KoreanbotsEndPoints } from '@utils/Constants'
+import { getToken } from '@utils/Csrf'
+import Day from '@utils/Day'
+import Fetch from '@utils/Fetch'
+import { getJosaPicker } from 'josa'
+import { NextSeo } from 'next-seo'
+import NotFound from 'pages/404'
+import { useEffect, useRef, useState } from 'react'
 
 const Container = dynamic(() => import('@components/Container'))
 const ServerIcon = dynamic(() => import('@components/ServerIcon'))
@@ -99,7 +99,7 @@ const VoteServer: NextPage<VoteServerProps> = ({ data, user, theme, csrfToken })
 					<Advertisement />
 					<Link href={makeServerURL(data)} className='text-blue-500 hover:opacity-80'>
 						<i className='fas fa-arrow-left mb-3 mt-3' /> <strong>{data.name}</strong>
-						{getJosaPicker('로')(data.name)}돌아가기
+						{getJosaPicker('로')(data.name)} 돌아가기
 					</Link>
 					<Segment className='mb-16 py-8'>
 						<div className='text-center'>

--- a/pages/users/[id]/report.tsx
+++ b/pages/users/[id]/report.tsx
@@ -1,7 +1,7 @@
-import { NextPage } from 'next'
-import Link from 'next/link'
-import dynamic from 'next/dynamic'
 import { Field, Form, Formik } from 'formik'
+import { NextPage } from 'next'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
 
 import { CsrfContext, ResponseProps, User } from '@types'
 import { get } from '@utils/Query'
@@ -9,15 +9,15 @@ import { makeUserURL, parseCookie } from '@utils/Tools'
 
 import { ParsedUrlQuery } from 'querystring'
 
-import NotFound from 'pages/404'
-import { getToken } from '@utils/Csrf'
 import { DMCA, TextField } from '@components/ReportTemplate'
-import { useState } from 'react'
+import { reportCats } from '@utils/Constants'
+import { getToken } from '@utils/Csrf'
 import Fetch from '@utils/Fetch'
 import { ReportSchema } from '@utils/Yup'
 import { getJosaPicker } from 'josa'
-import { reportCats } from '@utils/Constants'
 import { NextSeo } from 'next-seo'
+import NotFound from 'pages/404'
+import { useState } from 'react'
 
 const Container = dynamic(() => import('@components/Container'))
 const Message = dynamic(() => import('@components/Message'))
@@ -50,7 +50,7 @@ const ReportUser: NextPage<ReportUserProps> = ({ data, user, csrfToken }) => {
 			<NextSeo title={`${data.globalName} 신고하기`} />
 			<Link href={makeUserURL(data)} className='text-blue-500 hover:opacity-80'>
 				<i className='fas fa-arrow-left mb-3 mt-3' /> <strong>{data.globalName}</strong>
-				{getJosaPicker('로')(data.globalName)}돌아가기
+				{getJosaPicker('로')(data.globalName)} 돌아가기
 			</Link>
 			{reportRes?.code === 200 ? (
 				<Message type='success'>


### PR DESCRIPTION
신고 투표 페이지에 표시되었던 상단 돌아가기 링크의 띄어쓰기 문제를 해결하였습니다

{bot/serverName}{josa 으/로} 돌아가기

## 전
<img width="391" alt="image" src="https://github.com/user-attachments/assets/07032745-3007-42d0-bb84-69822ff910a1" />

## 후
<img width="328" alt="image" src="https://github.com/user-attachments/assets/155bf9f7-edef-488c-afd0-c6fcb333a8c4" />
