### PR TITLE
fix: 라이트모드 네비게이션바 스타일 개선

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -51,12 +51,16 @@ const Navbar: React.FC<NavbarProps> = ({ token }) => {
 			setUserCache(null)
 		}
 	}, [token])
-	
+
 	return (
-		<div className='fixed top-0 left-0 right-0 z-50'>
-			<nav className={`fixed top-0 z-40 flex w-full flex-wrap items-center justify-between px-2 py-2 text-gray-100 transition-colors duration-300 backdrop-blur-sm ${
-    dev ? 'bg-discord-blurple dark:bg-discord-black' : 'bg-discord-blurple/30 dark:bg-discord-black/30'
-  } lg:absolute`}>
+		<div className='fixed left-0 right-0 top-0 z-50'>
+			<nav
+				className={`fixed top-0 z-40 flex w-full flex-wrap items-center justify-between px-2 py-2 text-gray-100 backdrop-blur-sm transition-colors duration-300 ${
+					dev
+						? 'bg-discord-blurple dark:bg-discord-black'
+						: 'bg-discord-blurple/90 dark:bg-discord-black/30'
+				} lg:absolute`}
+			>
 				<div className='container mx-auto flex flex-wrap items-center justify-between px-4'>
 					<div className='relative flex w-full justify-between lg:w-auto lg:justify-start'>
 						<Link
@@ -65,19 +69,13 @@ const Navbar: React.FC<NavbarProps> = ({ token }) => {
 								dev ? 'dark:text-koreanbots-blue ' : ''
 							}logofont text-large whitespace-no-wrap mr-4 inline-block py-2 font-semibold uppercase leading-relaxed hover:text-gray-300 sm:text-2xl`}
 						>
-              {dev ? (
-              <>
-                <i className='fas fa-tools mr-1' /> DEVELOPERS
-              </>
-              ) : (
-                <Image
-                  src={Logo}
-                  alt='Koreanbots'
-                  width={100}
-                  height={100}
-                  className='h-10 w-10'
-                />
-              )}
+							{dev ? (
+								<>
+									<i className='fas fa-tools mr-1' /> DEVELOPERS
+								</>
+							) : (
+								<Image src={Logo} alt='Koreanbots' width={100} height={100} className='h-10 w-10' />
+							)}
 						</Link>
 						<button
 							className='block cursor-pointer rounded border border-solid border-transparent bg-transparent px-3 py-1 text-xl leading-none outline-none focus:outline-none dark:text-gray-200 lg:hidden'


### PR DESCRIPTION
<img width="713" alt="image" src="https://github.com/user-attachments/assets/02b1193b-87e4-4ec5-9e55-ebac23c5a555" />

<img width="672" alt="image" src="https://github.com/user-attachments/assets/9aa3dd3f-240d-4c3e-a718-92d28d20ffa6" />
투명도를 낮춰 라이트모드에서 시인성과 심미성을 개선하였습니다.
다른 보완 방법도 생각해봐야 할 것 같습니다