### PR TITLE
fix: 캐시 레포지토리의 싱글톤 보장

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,6 +2,7 @@
 import * as Yup from 'yup'
 import { Client } from 'discord.js'
 import NotificationManager from '@utils/NotificationManager'
+import { CacheManager } from '@utils/Query'
 
 declare global {
 	interface Window {
@@ -14,6 +15,7 @@ declare global {
 	var kodl: Client
 	var serverlist: Client
 	var notification: NotificationManager
+	var get: CacheManager
 	interface Navigator {
 		standalone?: boolean
 	}

--- a/utils/Query.ts
+++ b/utils/Query.ts
@@ -1199,7 +1199,7 @@ async function viewBot(id: string) {
 		await Bots.findByIdAndUpdate(id, { $push: { viewMetrix: { count: 0 } } }, { upsert: true })
 }
 
-export const get = {
+const _get = {
 	discord: {
 		user: new DataLoader(
 			async (ids: string[]) =>
@@ -1413,6 +1413,14 @@ export const get = {
 		token: getNotificationsByToken,
 	},
 }
+
+export type CacheManager = typeof _get
+
+if (!global.get) {
+	global.get = _get
+}
+
+export const get = global.get
 
 export const update = {
 	assignToken,


### PR DESCRIPTION
- Data Fetching 캐싱을 주관하는 DataLoader의 싱글톤을 보장합니다.
- 봇 / 서버 수정 시 invalidate(DataLoader#clear)를 사용해도 실제로는 반영되지 않던 문제를 해결합니다.